### PR TITLE
기타: 강사용 페이지의 출석체크 페이지 오류 수정

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -14,17 +14,22 @@
 	</classpathentry>
 	<classpathentry kind="src" output="bin/test" path="src/test/java">
 		<attributes>
+			<attribute name="test" value="true"/>
 			<attribute name="gradle_scope" value="test"/>
 			<attribute name="gradle_used_by_scope" value="test"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jst.server.core.container/org.eclipse.jst.server.tomcat.runtimeTarget/Apache Tomcat v9.0"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/src/main/java/com/project/controller/MainController.java
+++ b/src/main/java/com/project/controller/MainController.java
@@ -99,8 +99,16 @@ public class MainController {
 			} else {
 				courseId = mainSO.checkCourseForCourseId(memberId);
 				if (courseId > 0) {
-					model.addAttribute("info", mainSO.getInfoByCourseId(courseId));
-					model.addAttribute("stats", mainSO.getStatsByCourseId(courseId));
+					try {
+						model.addAttribute("info", mainSO.getInfoByCourseId(courseId));
+					} catch (Exception e) {
+						System.out.println("정보 오류");
+					}
+					try {
+						model.addAttribute("stats", mainSO.getStatsByCourseId(courseId));
+					} catch (Exception e) {
+						System.out.println("통계 오류");
+					}
 					viewPath = "main/checkin_i";
 				}
 			}

--- a/src/main/java/com/project/service/MainSO.java
+++ b/src/main/java/com/project/service/MainSO.java
@@ -115,6 +115,12 @@ public class MainSO extends ItemSO {
 	}
 
 	public StatsItem getStatsByCourseId(int courseId) {
+		boolean attended = courseItemDAO.checkAttendStatus(courseId) > 0;
+		System.out.println(attended);
+		if (!attended) {
+			/* 만일 출석 데이터가 존재하지 않다면 */
+			courseItemDAO.initAttendance(courseId);
+		}
 		return courseItemDAO.getStatsByCourseId(courseId);
 	}
 


### PR DESCRIPTION
출석한 학생의 데이터가 아예 없는 경우 통계 조회가 불가능하여 발생하는 오류 해결
금일 학생들의 출석 데이터가 없으면 해당 강의를 수강하는 학생들의 정보를 일괄 삽입